### PR TITLE
Small Typo-Fix: Triggered errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ In some case you can render static JSON-LD (like Organization or Website) and ne
             name: Your website name
             potentialAction:
                 @type: SearchAction
-                target:http://yourdomain.com/?s={search_term_string}
-                "query-input": "required name=search_term_string"
-            }
+                target: http://yourdomain.com/?s={search_term_string}
+                "query-input": "required name=search_term_string"            
           organization:
             @context: http://schema.org
             @type: Organization


### PR DESCRIPTION
The second example works fine – thank you for all!
Two small typos (missing space after target: and unneeded curly brace) stopped a short time with error-throwing because of copy-paste for first-try.