### PR TITLE
Update README.md : small typo and update target

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ In some case you can render static JSON-LD (like Organization or Website) and ne
             name: Your website name
             potentialAction:
                 @type: SearchAction
-                target:http://yourdomain.com/?s={search_term_string}
-                "query-input": "required name=search_term_string"
-            }
+                target: http://yourdomain.com/?search[word]={search_term_string}
+                query-input: "required name=search_term_string"            
           organization:
             @context: http://schema.org
             @type: Organization


### PR DESCRIPTION
Small Typo:
- space after target: 
- curly bracket after potentialAction throws  an error

With simpleSearch getParam search[word] is working. If elasticSearch has same API (I guess/hope), the change could help all while trying your package.