### PR TITLE
TASK: Lower package requirement constraints to support Neos 8.x

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,6 +1,4 @@
-namespace: Fusion = Neos.Fusion
-
-prototype(Ttree.LinkedData:Decorator) < prototype(Fusion:Value) {
+prototype(Ttree.LinkedData:Decorator) < prototype(Neos.Fusion:Value) {
 	value = ${value}
 
 	preset = 'default'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "neos-package",
     "license": "MIT",
     "require": {
-        "neos/neos": "^3.0 || ^4.0"
+        "neos/neos": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi Dominique,

Neos 8.x doesn't support fusion namespaces anymore and since I don't assume, that the Eel Helper won't change much regarding it's interface, I would suggest to change the package requirements to all Neos versions so, hopefully, we don't need to touch this package much in the future.

What do you think?